### PR TITLE
Update the Code Analysis action with the latest version of Detekt

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -22,11 +22,13 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
-    - name: Setup Detekt
+    - name: Download Detekt
       run: |
-        dest=$( mktemp -d )
-        curl --request GET --url $DETEKT_URL --location --output $dest/detekt
-        java -jar $dest/detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
+        curl --request GET --url $DETEKT_URL --location --output ${{ github.workspace }}/detekt
+    - name: Run Detekt
+      continue-on-error: true
+      run: |
+        java -jar ${{ github.workspace }}/detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
     - name: Upload
       uses: github/codeql-action/upload-sarif@v2
       with:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -25,13 +25,11 @@ jobs:
     - name: Setup Detekt
       run: |
         dest=$( mktemp -d )
-        curl --request GET --url $DETEKT_URL --silent --location --output $dest/detekt
-        chmod a+x $dest/detekt
-        echo $dest >> $GITHUB_PATH
+        curl --request GET --url $DETEKT_URL --location --output $dest/detekt
     - name: Run Detekt
       continue-on-error: true
       run: |
-        java -jar detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
+        java -jar $dest/detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
     - name: Upload
       uses: github/codeql-action/upload-sarif@v2
       with:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -24,13 +24,13 @@ on:
 env:
   # Release tag associated with the version of Detekt to be installed
   # SARIF support (required for this workflow) was introduced in Detekt v1.15.0
-  DETEKT_RELEASE_TAG: v1.15.0
+  DETEKT_RELEASE_TAG: v1.23.1
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "scan"
   scan:
-    name: Scan
+    name: Code Analysis
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     permissions:
@@ -40,6 +40,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout Code
     - uses: actions/checkout@v3
 
     # Gets the download URL associated with the $DETEKT_RELEASE_TAG
@@ -68,7 +69,7 @@ jobs:
         cat gh_response.json
 
         DETEKT_RELEASE_SHA=$(jq --raw-output '.data.repository.release.tagCommit.oid' gh_response.json)
-        if [ $DETEKT_RELEASE_SHA != "37f0a1d006977512f1f216506cd695039607c3e5" ]; then
+        if [ $DETEKT_RELEASE_SHA != "c50ed690da3794bf5e5a3bbbe56e15533f7cd0c8" ]; then
           echo "Release tag doesn't match expected commit SHA"
           exit 1
         fi
@@ -90,25 +91,13 @@ jobs:
 
     # Performs static analysis using Detekt
     - name: Run Detekt
-      continue-on-error: false
+      continue-on-error: true
       run: |
         detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
 
-    # Modifies the SARIF output produced by Detekt so that absolute URIs are relative
-    # This is so we can easily map results onto their source files
-    # This can be removed once relative URI support lands in Detekt: https://git.io/JLBbA
-    - name: Make artifact location URIs relative
-      continue-on-error: true
-      run: |
-        echo "$(
-          jq \
-            --arg github_workspace ${{ github.workspace }} \
-            '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \
-            ${{ github.workspace }}/detekt.sarif.json
-        )" > ${{ github.workspace }}/detekt.sarif.json
-
     # Uploads results to GitHub repository using the upload-sarif action
-    - uses: github/codeql-action/upload-sarif@v2
+    - name: Upload
+      uses: github/codeql-action/upload-sarif@v2
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: ${{ github.workspace }}/detekt.sarif.json

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout Code
-    - uses: actions/checkout@v3
+      uses: actions/checkout@v3
 
     # Gets the download URL associated with the $DETEKT_RELEASE_TAG
     - name: Get Detekt download URL
@@ -93,7 +93,7 @@ jobs:
     - name: Run Detekt
       continue-on-error: true
       run: |
-        detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
+        detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
 
     # Uploads results to GitHub repository using the upload-sarif action
     - name: Upload

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -26,9 +26,6 @@ jobs:
       run: |
         dest=$( mktemp -d )
         curl --request GET --url $DETEKT_URL --location --output $dest/detekt
-    - name: Run Detekt
-      continue-on-error: true
-      run: |
         java -jar $dest/detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
     - name: Upload
       uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,104 +1,39 @@
-# Scans are triggered:
-# 1. On every push to default and protected branches
-# 2. On every Pull Request targeting the default branch
-# 3. On a weekly schedule
-# 4. Manually, on demand, via the "workflow_dispatch" event
-#
-# The workflow should work with no modifications, but you might like to use a
-# later version of the Detekt CLI by modifying the $DETEKT_RELEASE_TAG
-# environment variable.
 name: Scan with Detekt
 
 on:
-  # Triggers the workflow on push or pull request events but only for default and protected branches
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   schedule:
      - cron: '20 21 * * 3'
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 env:
-  # Release tag associated with the version of Detekt to be installed
-  # SARIF support (required for this workflow) was introduced in Detekt v1.15.0
-  DETEKT_RELEASE_TAG: v1.23.1
+  DETEKT_URL: https://github.com/detekt/detekt/releases/download/v1.23.1/detekt-cli-1.23.1-all.jar
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "scan"
-  scan:
+  analysis:
     name: Code Analysis
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     permissions:
-      # required for all workflows
-      security-events: write
+      security-events: write # For uploading results
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout Code
       uses: actions/checkout@v3
-
-    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
-    - name: Get Detekt download URL
-      id: detekt_info
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
-          query getReleaseAssetDownloadUrl($tagName: String!) {
-            repository(name: "detekt", owner: "detekt") {
-              release(tagName: $tagName) {
-                releaseAssets(name: "detekt", first: 1) {
-                  nodes {
-                    downloadUrl
-                  }
-                }
-                tagCommit {
-                  oid
-                }
-              }
-            }
-          }
-        ' 1> gh_response.json
-
-        cat gh_response.json
-
-        DETEKT_RELEASE_SHA=$(jq --raw-output '.data.repository.release.tagCommit.oid' gh_response.json)
-        if [ $DETEKT_RELEASE_SHA != "c50ed690da3794bf5e5a3bbbe56e15533f7cd0c8" ]; then
-          echo "Release tag doesn't match expected commit SHA"
-          exit 1
-        fi
-
-        DETEKT_DOWNLOAD_URL=$(jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' gh_response.json)
-        echo "download_url=$DETEKT_DOWNLOAD_URL" >> $GITHUB_OUTPUT
-
-    # Sets up the detekt cli
     - name: Setup Detekt
       run: |
         dest=$( mktemp -d )
-        curl --request GET \
-          --url ${{ steps.detekt_info.outputs.download_url }} \
-          --silent \
-          --location \
-          --output $dest/detekt
+        curl --request GET --url $DETEKT_URL --silent --location --output $dest/detekt
         chmod a+x $dest/detekt
         echo $dest >> $GITHUB_PATH
-
-    # Performs static analysis using Detekt
     - name: Run Detekt
       continue-on-error: true
       run: |
-        detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
-
-    # Uploads results to GitHub repository using the upload-sarif action
+        java -jar detekt --input ${{ github.workspace }} --base-path ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
     - name: Upload
       uses: github/codeql-action/upload-sarif@v2
       with:
-        # Path to SARIF file relative to the root of the repository
         sarif_file: ${{ github.workspace }}/detekt.sarif.json
         checkout_path: ${{ github.workspace }}


### PR DESCRIPTION
- Update the version of Detekt to match the one use by IntelliJ. 
- Simplify and fix the download logic to work with recent Detekt releases. 
- Simplify the relative path logic since Detekt supports that natively now. 
- Some minor cleanup. 